### PR TITLE
Ignorando arquivos em src/upload.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ docker/lab-mysql/mysql
 docker/lab-webserver/logs
 docker/lab-webserver/facialRecognitionLogin
 
+src/upload
+
 .vscode/launch.json
 
 *.code-workspace


### PR DESCRIPTION
Os arquivos da pasta src/upload são salvos com a utilização do sistema (upload feito pelo usuário), portanto não fazem parte do código fonte do sistema. Para evitar incluir esses arquivos ao git, estou incluindo no arquivo .gitignore
